### PR TITLE
PEX-10150: Publish image to Docker Hub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,9 +12,9 @@ jobs:
       # build the application image
       - run:
           name: Build image
-          command: docker build -t 695480609797.dkr.ecr.eu-central-1.amazonaws.com/signavio-circle-ci-corretto:11.0.4 .
+          command: docker build -t signavio/circle-ci-java:latest .
 
       # deploy the image
       - run:
           name: Push to docker hub
-          command: docker push 695480609797.dkr.ecr.eu-central-1.amazonaws.com/signavio-circle-ci-corretto:11.0.4
+          command: docker push signavio/circle-ci-java:latest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,9 @@ version: 2
 jobs:
   build:
     machine: true
+    filters:
+      branches:
+        only: master
     steps:
       - checkout
       # - setup_remote_docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
       # - setup_remote_docker
       - run:
           name: Docker login
-          command: eval $(aws ecr get-login --region eu-central-1 --no-include-email)
+          command: docker login -u $DOCKER_USER -p $DOCKER_PASS
 
       # build the application image
       - run:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM 695480609797.dkr.ecr.eu-central-1.amazonaws.com/signavio-amazoncorretto:11.0.4
+FROM amazoncorretto:11
+ENV LANG C.UTF-8
 
 RUN yum -y update
 RUN yum -y install git tar gzip ca-certificates wget curl gettext


### PR DESCRIPTION
This is required such that we can use these images in the CircleCI pipline.
We are already doing the same for nodeJS images.